### PR TITLE
Add setup.py so build/install instructions in README will work.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+import setuptools
+
+setuptools.setup(
+   name="bufkit-api",
+   version="1.1",
+   description="Provides a Python interface to BUFKIT BUFR files.",
+   url="https://github.com/HumphreysCarter/bufkit-api",
+   author="Carter Humphreys",
+   packages=setuptools.find_packages(include=["bufkit*"])
+)


### PR DESCRIPTION
Resolves #2 by adding a _setup.py_ consistent with the instructions in _README.md_.